### PR TITLE
Make code compatible with slint 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 
 
 [dependencies]
-slint = { version = "0.3.4", default-features = false, features = ["compat-0-3-0"] }
+slint = { version = "1.0.0", default-features = false, features = ["compat-1-0"] }
 
 # for the rp-pico, replace by the hal for your crate
 rp-pico = { version = "0.5", optional = true }
@@ -24,7 +24,7 @@ embedded-hal = {version = "0.2.7", optional = true }
 fugit = { version = "0.3.6", optional = true }
 
 [build-dependencies]
-slint-build = { version = "0.3.4" }
+slint-build = { version = "1.0.0" }
 
 
 [features]


### PR DESCRIPTION
I tested both the simluator and have the demo booting on my pico.

Obviously we need to keep this open till after slint 1.0 is released.