### PR TITLE
Properly set the size of the slint window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,12 @@ name = "{{project-name}}"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
-rust-version = "1.68" # Because of the allocator
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 
 [dependencies]
-slint = { version = "1.0.0", default-features = false, features = ["compat-1-0"] }
+slint = { version = "1.7", default-features = false, features = ["compat-1-2", "renderer-software"] }
 
 # for the rp-pico, replace by the hal for your crate
 rp-pico = { version = "0.5", optional = true }
@@ -25,11 +24,11 @@ embedded-hal = {version = "0.2.7", optional = true }
 fugit = { version = "0.3.6", optional = true }
 
 [build-dependencies]
-slint-build = { version = "1.0.0" }
+slint-build = { version = "1.7" }
 
 
 [features]
-simulator = ["slint/renderer-winit-software", "slint/backend-winit"]
+simulator = ["slint/backend-winit"]
 pico = [
     "slint/unsafe-single-threaded",
     "slint/libm",

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ fn main() -> ! {
 
     // -------- Setup the Slint backend --------
     let window = slint::platform::software_renderer::MinimalSoftwareWindow::new(Default::default());
+    window.set_size(slint::PhysicalSize::new(320, 240));
     slint::platform::set_platform(alloc::boxed::Box::new(MyPlatform {
         window: window.clone(),
         timer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
     static mut HEAP: [u8; HEAP_SIZE] = [0; HEAP_SIZE];
     #[global_allocator]
     static ALLOCATOR: embedded_alloc::Heap = embedded_alloc::Heap::empty();
-    unsafe { ALLOCATOR.init(&mut HEAP as *const u8 as usize, core::mem::size_of_val(&HEAP)) };
+    unsafe { ALLOCATOR.init(core::ptr::addr_of_mut!(HEAP) as usize, HEAP_SIZE) }
 
     // -------- Setup peripherials --------
     let mut pac = pac::Peripherals::take().unwrap();


### PR DESCRIPTION
Fix template not working since Slint 1.4
Fixes https://github.com/slint-ui/slint-mcu-rust-template/issues/4
that regressed in commit e0efbc49bd11072a05bef3b91db91879b5513231


Also take the opportunity to modernize a bit to Slint 1.7 standards
(But did not change the other pico dependencies)