### PR TITLE
Replace the deprecated `-Cinline-threshold` flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -25,7 +25,7 @@
 rustflags = [
     "-C", "link-arg=--nmagic",
     "-C", "link-arg=-Tlink.x",
-    "-C", "inline-threshold=5",
+    "-C", "llvm-args=--inline-threshold=5",
     "-C", "no-vectorize-loops",
 ]
 


### PR DESCRIPTION
When I build I get a lot of warnings like:

warning: the `-Cinline-threshold` flag is deprecated and does nothing (consider using `-Cllvm-args=--inline-threshold=...`)

This should fix it.